### PR TITLE
feat: Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM ghcr.io/hankei6km/h6-dev-containers:rust
+
+
+ARG USERNAME=vscode
+WORKDIR "/home/${USERNAME}"
+USER ${USERNAME}
+
+RUN mkdir -p "/home/${USERNAME}/tmp" \
+  && cd "/home/${USERNAME}/tmp"  \
+  && git clone --depth 1 https://github.com/second-state/wasmedge-quickjs.git \
+  && rustup target add wasm32-wasi \
+  && sh -c 'curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash'

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,45 @@
+{
+  "name": "rust",
+  // "image": "ghcr.io/hankei6km/h6-dev-containers:rust",
+  "build": {
+    "context": ".",
+    "dockerfile": "Dockerfile"
+  },
+  "runArgs": ["--init", "--privileged"],
+  "overrideCommand": false,
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "uname -a",
+
+  // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "vscode",
+  "remoteEnv": {
+    "GDFUSE_SA": "${localEnv:GDFUSE_SA}",
+    "BOOTSTRAP_CODE": "${localEnv:BOOTSTRAP_CODE}"
+  },
+  "postStartCommand": [
+    "bash",
+    "-c",
+    "/home/vscode/.local/bin/mount-gd.sh /home/vscode/gdrive && echo 'source \"${HOME}/.wasmedge/env\"' >> /home/vscode/.bashrc"
+  ],
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "lldb.executable": "/usr/bin/lldb",
+        "files.watcherExclude": {
+          "**/target/**": true
+        },
+        "rust-analyzer.checkOnSave.command": "clippy"
+      },
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "vadimcn.vscode-lldb",
+        "tamasfe.even-better-toml",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
- clone `wasmedge-quickjs` into `$HOME/tmp`
- add `wasm32-wasi` target
- add WasmEdge runtime to user environment
